### PR TITLE
Version 1.6.3 - Hotfix release 🔨

### DIFF
--- a/languages/woo-additional-terms.pot
+++ b/languages/woo-additional-terms.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-3.0.
 msgid ""
 msgstr ""
-"Project-Id-Version: Woo Additional Terms 1.6.1\n"
+"Project-Id-Version: Woo Additional Terms 1.6.3\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/woo-additional-terms\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2023-08-11T09:10:47+00:00\n"
+"POT-Creation-Date: 2023-08-23T10:14:46+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.8.1\n"
 "X-Domain: woo-additional-terms\n"
@@ -247,7 +247,7 @@ msgctxt "admin notice"
 msgid "I already did!"
 msgstr ""
 
-#: templates/order/terms-acceptance.php:24
+#: templates/order/terms-acceptance.php:30
 msgid "Additional terms and conditions:"
 msgstr ""
 
@@ -329,8 +329,4 @@ msgstr ""
 #: assets/js/block.js:127
 #: assets/js/minified/block.js:1
 msgid "You haven’t set up an additional Terms and Conditions page."
-msgstr ""
-
-#: assets/js/minified/checkout.js:1
-msgid "Please read and accept the additional terms and conditions to proceed with your order."
 msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://mypreview.one/woo-additional-terms
 Requires at least: 5.0
 Tested up to: 6.3
 Requires PHP: 7.4
-Stable tag: 1.6.2
+Stable tag: 1.6.3
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.txt
 
@@ -123,6 +123,10 @@ Yes, it does. The [Woo Additional Terms PRO](https://mypreview.one/woo-additiona
 5. Additional terms and condition checkbox on the WooCommerce checkout block page.
 
 == Changelog ==
+= 1.6.3 =
+* Fix: Resolved the issue that prevented the assignment of non-published pages as terms pages.
+* Fix: Addressed a PHP error that occurred when retrieving order meta information for display on the order page.
+
 = 1.6.2 =
 * Fix: Isolated the dependency injection container package to prevent potential PHP fatal errors when utilized by other third-party plugins.
 

--- a/src/Admin/Order.php
+++ b/src/Admin/Order.php
@@ -53,7 +53,7 @@ class Order {
 		woo_additional_terms()->service( 'template_manager' )->echo_template(
 			'order/terms-acceptance.php',
 			array(
-				'value' => get_post_meta( $order->get_id(), self::META_KEY, true ),
+				'meta' => get_post_meta( $order->get_id(), self::META_KEY, true ),
 			)
 		);
 	}

--- a/src/Admin/Order.php
+++ b/src/Admin/Order.php
@@ -53,7 +53,7 @@ class Order {
 		woo_additional_terms()->service( 'template_manager' )->echo_template(
 			'order/terms-acceptance.php',
 			array(
-				'value' => $order->get_meta( self::META_KEY ),
+				'value' => get_post_meta( $order->get_id(), self::META_KEY, true ),
 			)
 		);
 	}

--- a/src/WooCommerce/Terms.php
+++ b/src/WooCommerce/Terms.php
@@ -77,6 +77,13 @@ class Terms {
 			return '';
 		}
 
+		$display_action = woo_additional_terms()->service( 'options' )->get( 'action', 'embed' );
+
+		// Bail early, in case the display action is set to "New Tab", and the terms page is not published.
+		if ( 'publish' !== $terms_page->post_status && 'newtab' === $display_action ) {
+			return '';
+		}
+
 		return get_permalink( $terms_page );
 	}
 

--- a/src/WooCommerce/Terms.php
+++ b/src/WooCommerce/Terms.php
@@ -64,20 +64,20 @@ class Terms {
 	 */
 	private function get_page_uri() {
 
-		$terms_page_id = woo_additional_terms()->service( 'options' )->get( 'page', 0 );
-		$terms_page    = get_post( $terms_page_id );
+		$terms_page_id = woo_additional_terms()->service( 'options' )->get( 'page', false );
 
-		// Check if the terms page exists.
-		if ( ! $terms_page instanceof WP_Post ) {
+		if ( ! is_numeric( $terms_page_id ) ) {
 			return '';
 		}
 
-		// Check if the terms page is published.
-		if ( 'publish' !== $terms_page->post_status ) {
+		$terms_page = get_post( $terms_page_id );
+
+		// Check if the terms page exists, and is a page.
+		if ( ! ( $terms_page instanceof WP_Post ) || 'page' !== $terms_page->post_type ) {
 			return '';
 		}
 
-		return get_permalink( $terms_page_id );
+		return get_permalink( $terms_page );
 	}
 
 	/**
@@ -141,36 +141,22 @@ class Terms {
 			return '';
 		}
 
-		// Check if get_post() function exists.
-		if ( ! function_exists( 'get_post' ) ) {
-			return '';
-		}
+		$terms_page_id = woo_additional_terms()->service( 'options' )->get( 'page', false );
 
-		$terms_page_id = woo_additional_terms()->service( 'options' )->get( 'page', 0 );
-
-		// Bail early, in case the terms page ID is empty.
-		if ( empty( $terms_page_id ) ) {
+		// Bail early, in case the terms page ID is not valid.
+		if ( empty( $terms_page_id ) || ! function_exists( 'get_post' ) ) {
 			return '';
 		}
 
 		$terms_page = get_post( $terms_page_id );
 
-		// Check if the terms page exists.
-		if ( ! $terms_page instanceof WP_Post ) {
-			return '';
-		}
-
-		// Check if the terms page is published.
-		if ( 'publish' !== $terms_page->post_status ) {
-			return '';
-		}
-
-		// Check if the terms page has content.
-		if ( empty( $terms_page->post_content ) ) {
+		// Check if the terms page exists, and has content.
+		if ( ! ( $terms_page instanceof WP_Post ) || empty( $terms_page->post_content ) ) {
 			return '';
 		}
 
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		return apply_filters( 'the_content', $terms_page->post_content );
 	}
+
 }

--- a/src/WooCommerce/Terms.php
+++ b/src/WooCommerce/Terms.php
@@ -158,5 +158,4 @@ class Terms {
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		return apply_filters( 'the_content', $terms_page->post_content );
 	}
-
 }

--- a/templates/order/terms-acceptance.php
+++ b/templates/order/terms-acceptance.php
@@ -15,6 +15,12 @@ if ( empty( $args['meta'] ) ) {
 	return;
 }
 
+// This block is intended for ensuring backward compatibility with versions older than 1.6.0.
+// It's worth noting that in previous versions, the acceptance value was stored within an array.
+if ( is_array( $args['meta'] ) ) {
+	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+	$args['meta'] = 'yes';
+}
 ?>
 
 <?php /* incorrect CSS class added here, so it adopts styling we want. */ ?>

--- a/templates/order/terms-acceptance.php
+++ b/templates/order/terms-acceptance.php
@@ -11,7 +11,7 @@ defined( 'ABSPATH' ) || exit;
 defined( 'WC_VERSION' ) || exit;
 
 // Bailout, if no value found.
-if ( empty( $value ) ) {
+if ( empty( $args['meta'] ) ) {
 	return;
 }
 
@@ -22,7 +22,7 @@ if ( empty( $value ) ) {
 	<p>
 		<strong style="display:flex;gap:5px;">
 			<?php esc_html_e( 'Additional terms and conditions:', 'woo-additional-terms' ); ?>
-			<span class="status-<?php echo esc_attr( wc_string_to_bool( $value ) ? 'enabled' : 'disabled' ); ?>"></span>
+			<span class="status-<?php echo esc_attr( wc_string_to_bool( $args['meta'] ) ? 'enabled' : 'disabled' ); ?>"></span>
 		</strong>
 	</p>
 </div>

--- a/woo-additioanl-terms.php
+++ b/woo-additioanl-terms.php
@@ -26,7 +26,7 @@
  * Plugin Name:          Woo Additional Terms
  * Plugin URI:           https://mypreview.one/woo-additional-terms
  * Description:          Improve your checkout process by adding an extra checkbox for terms and conditions. Keep track of acceptance to ensure transparency and security.
- * Version:              1.6.2
+ * Version:              1.6.3
  * Author:               MyPreview
  * Author URI:           https://mypreview.one/woo-additional-terms
  * Requires at least:    5.9


### PR DESCRIPTION
```
= 1.6.3 =
* Fix: Resolved the issue that prevented the assignment of non-published pages as terms pages.
* Fix: Addressed a PHP error that occurred when retrieving order meta information for display on the order page.
```